### PR TITLE
Pull review of 2148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,83 @@
 kOS Mod Changelog
 =================
+
+# VTODO_RELEASE_NUM_HERE_WHEN_WE_RELEASE TODO_RELEASE_CUTE_NAME_HERE
+
+This release was primarily focused on speedups and smoothness
+of execution.  We welcomed a new developer (github username tsholmes)
+who contributed a lot of bottleneck analysis and code speedups.  The
+goal was to reduce the burden kOS causes to the physics rate of the
+game, and consequently also allow tech tree scaled performance by era
+for the kOS computer parts themselves (slow at first, faster later).
+
+### BREAKING CHANGES:
+
+- Files now have an implied local scope, causing the following change:
+  - **Previously:** If you declared a variable as ``local`` at the
+    outermost scope of a program file (outside any curly braces),
+    then it had the same effect as ``global``, creating a varible
+    that you could see from anywhere outside that program file.
+  - **New behaviour:** Now that there is an outermost scope for a file,
+    ``local`` actually means something in that scope.  To get the
+    old behaviour you would need to explicitly call the variable
+    ``global``.i
+  (The variables magically created via the lazyglobal system will still
+  be global just like they were before.)
+- Parameters to programs now have local scope to that program file.
+  (Previously they were sort of global and visible everywhere, which
+  they shouldn't have been.  If you relied on this behaviour your
+  script might break.)
+- Functions declared at the outermost scope of a program will now
+  keep proper closure, making them see variables local to that program
+  file even when called from outside that file.  This may hide a global
+  variable with a more local variable of the same name, when previously
+  the global variable would have been accessible from the function.
+  (You probably weren't relying on this buggy behaviour before, but
+  if you were, this fix will break your script.)
+
+### NEW FEATURES:
+
+- TODO: Describe various speedups here, but not in too much detail.
+- **File scope**: Previously, kerboscript did not wrap program files
+  in their own local scope.  (Declaring a ``local`` in a file had
+  the same effect as declaring a ``global`` there).  Now each program file
+  has its own scope (and also the parameters passed to a program file
+  are local to that file scope).
+  - NOTE: For backward compatibility, there is one important exception
+    to the file scope - functions declared at the outermost level by
+    default can be globally seen in other programs.  You *CAN* get functions
+    that are local to the file's scope, but you have to explicitly include
+    the ``local`` keyword in the function declaration to make that happen.
+  [pull request](https://github.com/KSP-KOS/KOS/pull/2157)
+
+### BUG FIXES:
+
+- Functions at the outermost file scope level now have closures that can
+  see the file scope variables properly.  Previously they could not (but
+  this did not matter since there was no file scope to matter.  This bug
+  got exposed by the other file scope changes.)
+  [pull request](https://github.com/KSP-KOS/KOS/pull/2157)
+  
+
+
 # v1.1.3.2 (for KSP 1.3.1) New KSP version HOTFIX
+
 This version is functionally identical to v1.1.3.0, however the binaries are
 compiled against KSP 1.3.1 to allow it to properly load with the updated version
 of KSP
+
 ### BREAKING CHANGES:
+
 - This build will not work on previous versions of KSP.
+
 ### NEW FEATURES:
+
 (None)
+
 ### BUG FIXES:
+
 (None)
+
 # v1.1.3.1 (for KSP 1.2.2) Backward compatibility version of v1.1.3.0
 
 ### Only use if you are stuck on KSP 1.2.2.

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -2,8 +2,8 @@
 
 ## Definitions
 
-* [CamelCase](http://en.wikipedia.org/wiki/CamelCase) is a casing convention where the first letter is lower-case, words are not separated by any character but have their first letter capitalized. Example: <code>thisIsCamelCased</code>. 
-* [PascalCase](http://c2.com/cgi/wiki?PascalCase) is a casing convention where the first letter of each word is capitalized, and no separating character is included between words. Example: <code>ThisIsPascalCased</code>. 
+* [CamelCase](http://en.wikipedia.org/wiki/CamelCase) is a casing convention where the first letter is lower-case, words are not separated by any character but have their first letter capitalized. Example: <code>thisIsCamelCased</code>.
+* [PascalCase](http://c2.com/cgi/wiki?PascalCase) is a casing convention where the first letter of each word is capitalized, and no separating character is included between words. Example: <code>ThisIsPascalCased</code>.
 
 ## C# coding conventions
 
@@ -11,11 +11,31 @@ We should use the [Allman bracing style](http://en.wikipedia.org/wiki/Indent_sty
 
 We are using the C# coding conventions described in this document as a guide, not everything in this doc is gospel and is open to debate: [C# Coding Guidelines](http://blogs.msdn.com/brada/articles/361363.aspx) with the following exceptions:
 
-* Each file should not start with a copyright notice. The ones at the root of the source tree will suffice. 
-* Regions (#region) are not used. 
-* using statements are on top of a file (outside of namespace {...}) 
-* Use var only if you have an anonymous type or you can clearly tell what the type is from the right hand side of the expression 
+* Each file should not start with a copyright notice. The ones at the root of the source tree will suffice.
+* Regions (#region) are not used.
+* using statements are on top of a file (outside of namespace {...})
+* Use var only if you have an anonymous type or you can clearly tell what the type is from the right hand side of the expression
 * Member variables should always be private, public access should be provided by an encapsulated property.
+* While each source file should be limited to a single public class, nested
+  classes applicable to only their parent class are permited.
+* In the case of defining a kerboscript function class to serve as a constructor
+  for a specific structure, this function class should be nested at the top of
+  the structure it returns.  For example:
+  ```
+      public class ExampleStructure : Structure
+	  {
+		  [Function("example")] // insert the function at the top of the class
+		  public class FunctionExampleStructureConstructor
+		  {
+			  public override void Execute()
+			  {
+				  // insert logic here
+			  }
+		  }
+
+		  // insert member variables/constructors/methods per the style guide
+	  }
+  ```
 
 #### Naming
 Follow all .NET Framework Design Guidelines for both internal and external members. Highlights of these include:
@@ -69,7 +89,7 @@ Here is some sample code that follows these conventions.
 				}
 				return String.Empty;
 			}
-			
+
 			private string AnotherMethod(){
 				return privateMember.Count;
 			}

--- a/doc/source/language/user_functions.rst
+++ b/doc/source/language/user_functions.rst
@@ -50,26 +50,19 @@ DECLARE FUNCTION
 In kerboscript, you can make your own user functions using the
 DECLARE FUNCTION command, which has syntax as follows:
 
-  [``declare``] [``local``] ``function`` *identifier* ``{`` *statements* ``}`` *optional dot (.)*
+  [``declare``] [``local``|``global``] ``function`` *identifier* ``{`` *statements* ``}`` *optional dot (.)*
 
 The statement is called a "declare function" statement even when the optional
 word "declare" was left off.
 
-The following are all identical in meaning::
+::
 
     declare function hi { print "hello". }
     declare local function hi { print "hello". }
+    declare global function hi { print "hello". }
     local function hi { print "hello". }
+    global function hi { print "hello". }
     function hi { print "hello". }
-
-Functions are presumed to have scope local to the location where
-they are declared when the explicit local scope keyword is missing.
-
-At the moment, it is redundant to mention the ``local`` keyword,
-although it is allowed.
-
-It is best to just leave all the optional keywords of and merely say
-``function`` by itself.
 
 Example::
 
@@ -99,9 +92,34 @@ Example::
 
     print_corner(4,"That's me in the corner").
 
+Default varies when local or global are omitted
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the explicit ``local`` or ``global`` scope keyword is missing,
+the default that is chosen depends on where the function is declared.
+If the function was declared in the outermost file scope, it will be
+assumed to be global.  If it was declared inside some braces, it will
+be assumed to be local to those braces::
+
+    // f1 behaves as if it was declared global
+    // because this is the outermost file scope:
+    function f1 {
+       print "I am in f1".
+    }
+    if true {
+      // f2 behaves as if it was declared local
+      // because this is inside some braces ("{","}"):
+      function f2 {
+       print "I am in f2".
+      }
+      f2(). // can be called from here.
+    }
+    f2(). // This throws an error because f2 was local to the "if true" braces.
+    
 A declare function command can appear anywhere in a kerboscript program,
 and once its been "parsed" by the compiler, the function can be called
-from anywhere in the program.
+from anywhere in the program that is able to see the function according
+to the scoping rules.
 
 The best design pattern is probably to create your library of function
 calls as one or more separate .ks files that contain just function

--- a/doc/source/language/variables.rst
+++ b/doc/source/language/variables.rst
@@ -127,11 +127,11 @@ Initializer required in DECLARE
 .. note::
     .. versionadded:: 0.17
         The syntax without the initializer, looking like so:
-    
+
         .. code-block:: kerboscript
-        
+
             DECLARE x. // no initializer like "TO 1."
-        
+
         is **no longer legal syntax**.
 
 Kerboscript now requires the use of the initializer clause (the "TO"
@@ -561,12 +561,12 @@ thing is, as described next:
 
 ``FUNCTION`` **not in curly braces**: Functions that are declared at the outermost
 file scope, (i.e. outside of any curly braces) and don't mention ``global``
- or ``local`` in their declaration behave as if they have the ``global`` keyword
+or ``local`` in their declaration behave as if they have the ``global`` keyword
 on them.  They can be called from any other program after this program has
 been run.
 
 ``FUNCTION`` **in curly braces**: Functions that are declared anywhere *inside* of some
-curly braces and don't mention ``global`` or ``local`` in their 
+curly braces and don't mention ``global`` or ``local`` in their
 declaration behave as if they have the ``local`` keyword on them.
 They can only be called from the local scope of those curly braces
 or deeper.

--- a/doc/source/language/variables.rst
+++ b/doc/source/language/variables.rst
@@ -42,11 +42,20 @@ The following alternate versions have identical meaning to each other:
 
 .. warning::
     .. versionadded:: 0.17
-        ***BREAKING CHANGE**
+        ** BREAKING CHANGE: **
         The meaning, and syntax, of this statement changed considerably
         in this update.  Prior to this version, DECLARE always created
         global variables no matter where it appeared in the script.
         See 'initializer required' below.
+
+.. warning::
+    .. versionadded:: 1.5
+        ** BREAKING CHANGE: **
+        Previously the outermost level of a program file was the global
+        scope.  Now each file has its own scope and the outermost level
+        is still nested "one scope inside" the global scope.  You now only
+        get global variables when you explicitly declare a variable as global,
+        or when you rely on the lazyglobal system to make them for you.
 
 Detailed Description of the syntax:
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -91,12 +100,13 @@ See Scoping:
 
 .. note::
     It is implied that the outermost scope of a program file is
-    the global scope.  Therefore if you make a LOCAL variable at
-    the outermost nesting level of your program it really ends up
-    being GLOBAL.  Note that GLOBAL variables are not only shared
+    also a local scope, as if the entire program file had been
+    wrapped inside an invisible set of curly braces.
+    Note that GLOBAL variables are not only shared
     between functions of your script, but also can be seen by
     other programs you run from the current program, and visa
-    versa.
+    versa.  But local variables you make at the outermost scope
+    of a file won't be.
 
 Alternatively, a variable can be implicitly declared by any ``SET`` or
 ``LOCK`` statement, however doing so causes the variable to always have
@@ -247,14 +257,15 @@ only gets executed if the system needed to pad a missing argument.
 
     The following paragraph is important for people familiar with other programming languages. If you are new to programming and don't understand what it is saying, that's okay you can ignore it.
 
-    At the moment the only kind of parameter supported is a pass-by-value parameter, and pass-by reference parameters don't exist. Be aware, however, that due to the way kOS is implemented on top of a reference-using object-oriented language (CSharp), if you pass an argument which is a complex aggregate structure (i.e. a Vector, or a List - anything that kOS lets you use a colon suffix with), then the parameters will behave exactly like being passed by reference because all you're passing is the handle to the object rather than the object itself. This should be familiar behavior to anyone who has written software in Java or C# before.
+    At the moment the only kind of parameter supported is a pass-by-value parameter, and pass-by reference parameters don't exist. Be aware, however, that due to the way kOS is implemented on top of a reference-using object-oriented language (CSharp), if you pass an argument which is a complex aggregate structure (i.e. a Vector, or a List - anything that isn't just a single scalar, boolean, or string), then the parameters will behave exactly like being passed by reference because all you're passing is the handle to the object rather than the object itself. This should be familiar behavior to anyone who has written software in Java or C# before.
 
 .. _set:
 
 ``SET``
 -------
 
-Sets the value of a variable. Implicitly creates a global variable if it doesn’t already exist::
+Sets the value of a variable. Implicitly creates a global variable if it doesn't already exist,
+unless :ref:`the @lazyglobal off<lazyglobal>` directive has been given::
 
     SET X TO 1.
     SET X TO y*2 - 1.
@@ -511,7 +522,7 @@ Local Scope
     local to a function, but are in fact actually local to JUST
     the current curly-brace block of statements, even if that block
     of statements is, say, the body of an IF check, or the body of
-    an UNTIL loop.
+    an UNTIL loop.  A program file also has its own local scope.
 
 Why limit scope?
     You might be wondering why it's useful to limit the scope of a
@@ -542,13 +553,23 @@ Presumed defaults
 The DECLARE keyword and the LOCK keyword have some default
 presumed scoping behaviors:
 
-``DECLARE`` Is assumed to always be LOCAL when not otherwise specified.
+``DECLARE`` is assumed to always be LOCAL when used with a variable
+if the words ``local`` or ``global`` have been left off.
+When used with something that is not a variable, the presumed default
+(whether it's local versus global) varies depending on what the declared
+thing is, as described next:
 
-``FUNCTION`` Must always be LOCAL.  Declaring it as global has no effect,
-so the only way to make it be global is to declare it while at outermost
-scope.  This is because functions always remember their closures, and
-so to declare a function as global while it holds closure information
-about local variables would be contradictory.
+``FUNCTION`` **not in curly braces**: Functions that are declared at the outermost
+file scope, (i.e. outside of any curly braces) and don't mention ``global``
+ or ``local`` in their declaration behave as if they have the ``global`` keyword
+on them.  They can be called from any other program after this program has
+been run.
+
+``FUNCTION`` **in curly braces**: Functions that are declared anywhere *inside* of some
+curly braces and don't mention ``global`` or ``local`` in their 
+declaration behave as if they have the ``local`` keyword on them.
+They can only be called from the local scope of those curly braces
+or deeper.
 
 ``PARAMETER`` Cannot be anything but LOCAL to the location it's mentioned.
 It is an error to attempt to declare a parameter with the GLOBAL keyword.
@@ -568,10 +589,12 @@ igorned, see above under 'Presumed defaults'.)::
     //
     // These are all synonymous with each other:
     //
+    DECLARE X IS 1.
     DECLARE X TO 1.
+    DECLARE LOCAL X IS 1.
     DECLARE LOCAL X TO 1.
-    LOCAL X TO 1. // 'declare' is implied and optional when scoping words are used
     LOCAL X IS 1. // 'declare' is implied and optional when scoping words are used
+    LOCAL X TO 1. // 'declare' is implied and optional when scoping words are used
     //
     // These are all synonymous with each other:
     //
@@ -595,31 +618,29 @@ turned off LAZYGLOBAL.  (This only applies to trying to make
 a variable with **declare identifier to value**, and not to
 ``declare parameter`` or ``declare function``.)
 
+Program files also have an outer local scope
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Locals stated at the global level are global
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Note that if you put a statement at the outermost scope
-of the program, then there is effectively no difference
-between a ``DECLARE LOCAL`` (or just ``LOCAL`` for short)
-and a ``DECLARE GLOBAL`` (or just ``GLOBAL`` for short) statement.
-They are both going to make a variable at global scope because that's
-the scope the program was in when the statement was encountered.
+Note that even though program files don't need an outermost
+set of curly braces, they still have a local scope. If you
+put a ``DECLARE LOCAL`` statement at the outermost scope of
+the program, outside of any braces, then that variable will
+only be usable from inside that program file and that program
+file's functions.
 
 
 Examples::
 
     GLOBAL x IS 10. // X is now a global variable with value 10,
     SET y TO 20. // Y is now a global variable (implicitly) with value 20.
-    LOCAL z IS 0.  // Z is now a global variable
-                   // because even though this says LOCAL, it was
-                   // stated at the outermost, global scope.
+    LOCAL z IS 0.  // Z is now local to this file's outer scope. This is
+                   // not *quite* global because it means other program files
+                   // can't see it.
 
     SET sum to -1. // sum is now an implicitly made global variable, containing -1.
 
-    // A function to return the mean average of all the items in the list
-    // passed into it, under the assumption all the items in the list are
-    // numbers of some sort:
+    // This function is declared at the file's outer scope.
+    // It can be seen and called by other programs after this program is done.
     FUNCTION calcAverage {
       PARAMETER inputList.
 
@@ -637,7 +658,7 @@ Examples::
 
 .. highlight:: none
 
-This example will print::
+The above example will print::
 
 
     Inside calcAverage, sum is 30
@@ -648,6 +669,7 @@ This example will print::
 
 Thus proving that the variable called SUM inside the function is NOT the
 same variable as the one called SUM out in the global main code.
+
 
 Nesting
 ~~~~~~~

--- a/doc/source/structures/vessels/vessel.rst
+++ b/doc/source/structures/vessels/vessel.rst
@@ -46,7 +46,7 @@ All vessels share a structure. To get a variable referring to any vessel you can
     :attr:`VERTICALSPEED`                    :struct:`scalar` (m/s)          How fast the ship is moving "up"
     :attr:`GROUNDSPEED`                      :struct:`scalar` (m/s)          How fast the ship is moving "horizontally"
     :attr:`AIRSPEED`                         :struct:`scalar` (m/s)          How fast the ship is moving relative to the air
-    :attr:`TERMVELOCITY`(DEPRECATED)         :struct:`scalar` (m/s)          terminal velocity of the vessel
+    :attr:`TERMVELOCITY` (DEPRECATED)        :struct:`scalar` (m/s)          terminal velocity of the vessel
     :attr:`SHIPNAME`                         :struct:`string`                The name of the vessel
     :attr:`NAME`                             :struct:`string`                Synonym for SHIPNAME
     :attr:`STATUS`                           :struct:`string`                Current ship status

--- a/src/kOS.Safe/Compilation/KS/Compiler.cs
+++ b/src/kOS.Safe/Compilation/KS/Compiler.cs
@@ -2715,7 +2715,8 @@ namespace kOS.Safe.Compilation.KS
             ParseNode lastSubNode = node.Nodes[node.Nodes.Count-1];
 
             // Default varies depending on which kind of statement it is.
-            // locks are default global while everything else is default local:
+            // locks are default global, and functions declared at file
+            // scope are default global, while everything else is default local:
             StorageModifier modifier = StorageModifier.LOCAL;
             if (lastSubNode.Token.Type == TokenType.declare_lock_clause ||
                 lastSubNode.Token.Type == TokenType.declare_function_clause)

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -2073,7 +2073,7 @@ namespace kOS.Safe.Compilation
 
         public override string ToString()
         {
-            return Name + " " + EntryPoint.ToString();
+            return Name + " " + EntryPoint.ToString() + (WithClosure ? " closure" : "");
         }
     }
         

--- a/src/kOS.Safe/Encapsulation/Lexicon.cs
+++ b/src/kOS.Safe/Encapsulation/Lexicon.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using kOS.Safe.Utilities;
+using kOS.Safe.Function;
 
 namespace kOS.Safe.Encapsulation
 {
@@ -13,6 +14,21 @@ namespace kOS.Safe.Encapsulation
     [kOS.Safe.Utilities.KOSNomenclature("Lex", CSharpToKOS = false) ]
     public class Lexicon : SerializableStructure, IDictionary<Structure, Structure>, IIndexable
     {
+        [Function("lex", "lexicon")]
+        public class FunctionLexicon : SafeFunctionBase
+        {
+            public override void Execute(SafeSharedObjects shared)
+            {
+
+                Structure[] argArray = new Structure[CountRemainingArgs(shared)];
+                for (int i = argArray.Length - 1; i >= 0; --i)
+                    argArray[i] = PopStructureAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
+                AssertArgBottomAndConsume(shared);
+                var lexicon = new Lexicon(argArray.ToList());
+                ReturnValue = lexicon;
+            }
+        }
+
         public class LexiconComparer<TI> : IEqualityComparer<TI>
         {
             public bool Equals(TI x, TI y)

--- a/src/kOS.Safe/Encapsulation/ListValue.cs
+++ b/src/kOS.Safe/Encapsulation/ListValue.cs
@@ -5,6 +5,7 @@ using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Properties;
 using kOS.Safe.Serialization;
+using kOS.Safe.Function;
 
 namespace kOS.Safe.Encapsulation
 {
@@ -135,6 +136,20 @@ namespace kOS.Safe.Encapsulation
     [kOS.Safe.Utilities.KOSNomenclature("List", KOSToCSharp = false)] // one-way because the generic templated ListValue<T> is the canonical one.  
     public class ListValue : ListValue<Structure>
     {
+        [Function("list")]
+        public class FunctionList : SafeFunctionBase
+        {
+            public override void Execute(SafeSharedObjects shared)
+            {
+                Structure[] argArray = new Structure[CountRemainingArgs(shared)];
+                for (int i = argArray.Length - 1; i >= 0; --i)
+                    argArray[i] = PopStructureAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
+                AssertArgBottomAndConsume(shared);
+                var listValue = new ListValue(argArray.ToList());
+                ReturnValue = listValue;
+            }
+        }
+
         public ListValue()
         {
             InitializeSuffixes();

--- a/src/kOS.Safe/Encapsulation/PIDLoop.cs
+++ b/src/kOS.Safe/Encapsulation/PIDLoop.cs
@@ -1,11 +1,54 @@
 using System;
 using kOS.Safe.Encapsulation.Suffixes;
+using kOS.Safe.Function;
+using kOS.Safe.Exceptions;
 
 namespace kOS.Safe.Encapsulation
 {
     [kOS.Safe.Utilities.KOSNomenclature("PIDLoop")]
     public class PIDLoop : Structure
     {
+        [Function("pidloop")]
+        public class PIDLoopConstructor : SafeFunctionBase
+        {
+            public override void Execute(SafeSharedObjects shared)
+            {
+                int args = CountRemainingArgs(shared);
+                double kd;
+                double ki;
+                double kp;
+                double maxoutput;
+                double minoutput;
+                switch (args)
+                {
+                    case 0:
+                        this.ReturnValue = new PIDLoop();
+                        break;
+                    case 1:
+                        kp = GetDouble(PopValueAssert(shared));
+                        this.ReturnValue = new PIDLoop(kp, 0, 0);
+                        break;
+                    case 3:
+                        kd = GetDouble(PopValueAssert(shared));
+                        ki = GetDouble(PopValueAssert(shared));
+                        kp = GetDouble(PopValueAssert(shared));
+                        this.ReturnValue = new PIDLoop(kp, ki, kd);
+                        break;
+                    case 5:
+                        maxoutput = GetDouble(PopValueAssert(shared));
+                        minoutput = GetDouble(PopValueAssert(shared));
+                        kd = GetDouble(PopValueAssert(shared));
+                        ki = GetDouble(PopValueAssert(shared));
+                        kp = GetDouble(PopValueAssert(shared));
+                        this.ReturnValue = new PIDLoop(kp, ki, kd, maxoutput, minoutput);
+                        break;
+                    default:
+                        throw new KOSArgumentMismatchException(new[] { 0, 1, 3, 5 }, args);
+                }
+                AssertArgBottomAndConsume(shared);
+            }
+        }
+
         public static PIDLoop DeepCopy(PIDLoop source)
         {
             PIDLoop newLoop = new PIDLoop

--- a/src/kOS.Safe/Encapsulation/QueueValue.cs
+++ b/src/kOS.Safe/Encapsulation/QueueValue.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Serialization;
+using kOS.Safe.Function;
 
 namespace kOS.Safe.Encapsulation
 {
@@ -59,6 +60,20 @@ namespace kOS.Safe.Encapsulation
     [kOS.Safe.Utilities.KOSNomenclature("Queue", KOSToCSharp = false)] // one-way because the generic templated QueueValue<T> is the canonical one.  
     public class QueueValue : QueueValue<Structure>
     {
+        [Function("queue")]
+        public class FunctionQueue : SafeFunctionBase
+        {
+            public override void Execute(SafeSharedObjects shared)
+            {
+                Structure[] argArray = new Structure[CountRemainingArgs(shared)];
+                for (int i = argArray.Length - 1; i >= 0; --i)
+                    argArray[i] = PopStructureAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
+                AssertArgBottomAndConsume(shared);
+                var queueValue = new QueueValue(argArray.ToList());
+                ReturnValue = queueValue;
+            }
+        }
+
         public QueueValue()
         {
             InitializeSuffixes();

--- a/src/kOS.Safe/Encapsulation/StackValue.cs
+++ b/src/kOS.Safe/Encapsulation/StackValue.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Serialization;
+using kOS.Safe.Function;
 
 namespace kOS.Safe.Encapsulation
 {
@@ -65,6 +66,20 @@ namespace kOS.Safe.Encapsulation
     [kOS.Safe.Utilities.KOSNomenclature("Stack", KOSToCSharp = false)] // one-way because the generic templated StackValue<T> is the canonical one.  
     public class StackValue : StackValue<Structure>
     {
+        [Function("stack")]
+        public class FunctionStack : SafeFunctionBase
+        {
+            public override void Execute(SafeSharedObjects shared)
+            {
+                Structure[] argArray = new Structure[CountRemainingArgs(shared)];
+                for (int i = argArray.Length - 1; i >= 0; --i)
+                    argArray[i] = PopStructureAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
+                AssertArgBottomAndConsume(shared);
+                var stackValue = new StackValue(argArray.ToList());
+                ReturnValue = stackValue;
+            }
+        }
+
         public StackValue()
         {
             InitializeSuffixes();

--- a/src/kOS.Safe/Encapsulation/UniqueSetValue.cs
+++ b/src/kOS.Safe/Encapsulation/UniqueSetValue.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Serialization;
+using kOS.Safe.Function;
 
 namespace kOS.Safe.Encapsulation
 {
@@ -64,6 +65,20 @@ namespace kOS.Safe.Encapsulation
     [kOS.Safe.Utilities.KOSNomenclature("UniqueSet", KOSToCSharp = false)] // one-way because the generic templated UniqueSetValue<T> is the canonical one.
     public class UniqueSetValue : UniqueSetValue<Structure>
     {
+        [Function("uniqueset")]
+        public class FunctionSet : SafeFunctionBase
+        {
+            public override void Execute(SafeSharedObjects shared)
+            {
+                Structure[] argArray = new Structure[CountRemainingArgs(shared)];
+                for (int i = argArray.Length - 1; i >= 0; --i)
+                    argArray[i] = PopStructureAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
+                AssertArgBottomAndConsume(shared);
+                var setValue = new UniqueSetValue(argArray.ToList());
+                ReturnValue = setValue;
+            }
+        }
+
         public UniqueSetValue()
         {
             InitializeSuffixes();

--- a/src/kOS.Safe/Execution/Stack.cs
+++ b/src/kOS.Safe/Execution/Stack.cs
@@ -351,6 +351,12 @@ namespace kOS.Safe.Execution
             }
         }
 
+        /// <summary>
+        /// Finds a scope with the given ID number, from the top down.
+        /// If no such scope is found, it returns null.
+        /// </summary>
+        /// <returns>The scope.</returns>
+        /// <param name="ScopeId">Scope identifier.</param>
         public VariableScope FindScope(Int16 ScopeId)
         {
             for (int index = scopeCount - 1; index >= 0; --index)

--- a/src/kOS.Safe/Function/Misc.cs
+++ b/src/kOS.Safe/Function/Misc.cs
@@ -1,12 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using kOS.Safe.Compilation;
+﻿using kOS.Safe.Compilation;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Execution;
 using kOS.Safe.Module;
 using kOS.Safe.Persistence;
+using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace kOS.Safe.Function
 {
@@ -274,7 +274,6 @@ namespace kOS.Safe.Function
                 {
                     throw new KOSFileException("Can't append to file: not enough space or access forbidden");
                 }
-
             }
         }
     }
@@ -354,52 +353,11 @@ namespace kOS.Safe.Function
             StringBuilder sb = new StringBuilder();
             foreach (string textLine in shared.Cpu.ProfileResult)
             {
-                if (sb.Length > 0 )
+                if (sb.Length > 0)
                     sb.Append("\n");
                 sb.Append(textLine);
             }
             ReturnValue = sb.ToString();
-        }
-    }
-
-    [Function("pidloop")]
-    public class PIDLoopConstructor : SafeFunctionBase
-    {
-        public override void Execute(SafeSharedObjects shared)
-        {
-            int args = CountRemainingArgs(shared);
-            double kd;
-            double ki;
-            double kp;
-            double maxoutput;
-            double minoutput;
-            switch (args)
-            {
-            case 0:
-                this.ReturnValue = new PIDLoop();
-                break;
-            case 1:
-                kp = GetDouble(PopValueAssert(shared));
-                this.ReturnValue = new PIDLoop(kp, 0, 0);
-                break;
-            case 3:
-                kd = GetDouble(PopValueAssert(shared));
-                ki = GetDouble(PopValueAssert(shared));
-                kp = GetDouble(PopValueAssert(shared));
-                this.ReturnValue = new PIDLoop(kp, ki, kd);
-                break;
-            case 5:
-                maxoutput = GetDouble(PopValueAssert(shared));
-                minoutput = GetDouble(PopValueAssert(shared));
-                kd = GetDouble(PopValueAssert(shared));
-                ki = GetDouble(PopValueAssert(shared));
-                kp = GetDouble(PopValueAssert(shared));
-                this.ReturnValue = new PIDLoop(kp, ki, kd, maxoutput, minoutput);
-                break;
-            default:
-                throw new KOSArgumentMismatchException(new[] { 0, 1, 3, 5 }, args);
-            }
-            AssertArgBottomAndConsume(shared);
         }
     }
 

--- a/src/kOS.Safe/Function/Persistence.cs
+++ b/src/kOS.Safe/Function/Persistence.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using kOS.Safe.Compilation;
+﻿using kOS.Safe.Compilation;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Exceptions;
 using kOS.Safe.Persistence;
 using kOS.Safe.Serialization;
+using System;
 
 namespace kOS.Safe.Function
 {
@@ -11,6 +11,7 @@ namespace kOS.Safe.Function
      * A couple of syntaxes from kRISC.tpg were deprecated when subdirectories where introduced. It will be possible to
      * remove these function below as well any metions of delete/rename file/rename volume/copy from kRISC.tpg in the future.
      */
+
     [Function("copy_deprecated")]
     public class FunctionCopyDeprecated : SafeFunctionBase
     {
@@ -35,7 +36,7 @@ namespace kOS.Safe.Function
             }
 
             shared.Logger.LogWarningAndScreen(
-                string.Format( "WARNING: COPY {0} {1} {2} is deprecated as of kOS v1.0.0.  Use COPYPATH(\"{3}\", \"{4}\") instead.",
+                string.Format("WARNING: COPY {0} {1} {2} is deprecated as of kOS v1.0.0.  Use COPYPATH(\"{3}\", \"{4}\") instead.",
                               arg1.ToString(), arg2.ToString(), arg3.ToString(), fromName, toName));
 
             // Redirect into a call to the copypath function, so as to keep all
@@ -62,7 +63,7 @@ namespace kOS.Safe.Function
             AssertArgBottomAndConsume(shared);
 
             shared.Logger.LogWarningAndScreen(
-                string.Format( "WARNING: RENAME FILE {0} TO {1} is deprecated as of kOS v1.0.0.  Use MOVEPATH(\"{2}\", \"{3}\") instead.",
+                string.Format("WARNING: RENAME FILE {0} TO {1} is deprecated as of kOS v1.0.0.  Use MOVEPATH(\"{2}\", \"{3}\") instead.",
                               oldName, newName, oldName, newName));
 
             // Redirect into a call to the movepath function, so as to keep all
@@ -91,7 +92,7 @@ namespace kOS.Safe.Function
             Volume volume = oldArg is Volume ? oldArg as Volume : shared.VolumeMgr.GetVolume(oldName);
 
             shared.Logger.LogWarningAndScreen(
-                string.Format( "WARNING: RENAME VOLUME {0} TO {1} is deprecated as of kOS v1.0.0.  Use SET VOLUME({2}):NAME TO \"{3}\" instead.",
+                string.Format("WARNING: RENAME VOLUME {0} TO {1} is deprecated as of kOS v1.0.0.  Use SET VOLUME({2}):NAME TO \"{3}\" instead.",
                               oldName, newName, volume.Name, newName));
 
             volume.Name = newName;
@@ -114,7 +115,7 @@ namespace kOS.Safe.Function
                 pathName = fileName.ToString();
 
             shared.Logger.LogWarningAndScreen(
-                string.Format( "WARNING: DELETE {0}{1} is deprecated as of kOS v1.0.0.  Use DELETEPATH(\"{2}\") instead.",
+                string.Format("WARNING: DELETE {0}{1} is deprecated as of kOS v1.0.0.  Use DELETEPATH(\"{2}\") instead.",
                               fileName.ToString(), (volumeId == null ? "" : (" FROM " + volumeId.ToString())), pathName));
 
             // Redirect into a call to the deletepath function, so as to keep all
@@ -123,62 +124,6 @@ namespace kOS.Safe.Function
             shared.Cpu.PushArgumentStack(new kOS.Safe.Execution.KOSArgMarkerType());
             shared.Cpu.PushArgumentStack(pathName);
             shared.Cpu.CallBuiltinFunction("deletepath");
-        }
-    }
-
-    [Function("path")]
-    public class FunctionPath : SafeFunctionBase
-    {
-        public override void Execute(SafeSharedObjects shared)
-        {
-            int remaining = CountRemainingArgs(shared);
-
-            GlobalPath path;
-
-            if (remaining == 0)
-            {
-                path = GlobalPath.FromVolumePath(shared.VolumeMgr.CurrentDirectory.Path,
-                                                 shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume));
-            }
-            else
-            {
-                object pathObject = PopValueAssert(shared, true);
-                path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
-            }
-
-            AssertArgBottomAndConsume(shared);
-
-            ReturnValue = new PathValue(path, shared);
-        }
-    }
-
-    [Function("volume")]
-    public class FunctionVolume : SafeFunctionBase
-    {
-        public override void Execute(SafeSharedObjects shared)
-        {
-            int remaining = CountRemainingArgs(shared);
-
-            Volume volume;
-
-            if (remaining == 0)
-            {
-                volume = shared.VolumeMgr.CurrentVolume;
-            }
-            else
-            {
-                object volumeId = PopValueAssert(shared, true);
-                volume = shared.VolumeMgr.GetVolume(volumeId);
-
-                if (volume == null)
-                {
-                    throw new KOSPersistenceException("Could not find volume: " + volumeId);
-                }
-            }
-
-            AssertArgBottomAndConsume(shared);
-
-            ReturnValue = volume;
         }
     }
 
@@ -245,7 +190,6 @@ namespace kOS.Safe.Function
                 {
                     throw new KOSException("Invalid directory: " + pathObject);
                 }
-
             }
 
             AssertArgBottomAndConsume(shared);

--- a/src/kOS.Safe/Function/Suffixed.cs
+++ b/src/kOS.Safe/Function/Suffixed.cs
@@ -1,66 +1,8 @@
-﻿using System;
-using System.Linq;
-using kOS.Safe.Encapsulation;
+﻿using kOS.Safe.Encapsulation;
 using kOS.Safe.Exceptions;
 
 namespace kOS.Safe.Function
 {
-    [Function("list")]
-    public class FunctionList : SafeFunctionBase
-    {
-        public override void Execute(SafeSharedObjects shared)
-        {
-            Structure[] argArray = new Structure[CountRemainingArgs(shared)];
-            for (int i = argArray.Length - 1 ; i >= 0 ; --i)
-                argArray[i] = PopStructureAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
-            AssertArgBottomAndConsume(shared);
-            var listValue = new ListValue(argArray.ToList());
-            ReturnValue = listValue;
-        }
-    }
-
-    [Function("queue")]
-    public class FunctionQueue : SafeFunctionBase
-    {
-        public override void Execute(SafeSharedObjects shared)
-        {
-            Structure[] argArray = new Structure[CountRemainingArgs(shared)];
-            for (int i = argArray.Length - 1 ; i >= 0 ; --i)
-                argArray[i] = PopStructureAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
-            AssertArgBottomAndConsume(shared);
-            var queueValue = new QueueValue(argArray.ToList());
-            ReturnValue = queueValue;
-        }
-    }
-
-    [Function("stack")]
-    public class FunctionStack : SafeFunctionBase
-    {
-        public override void Execute(SafeSharedObjects shared)
-        {
-            Structure[] argArray = new Structure[CountRemainingArgs(shared)];
-            for (int i = argArray.Length - 1 ; i >= 0 ; --i)
-                argArray[i] = PopStructureAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
-            AssertArgBottomAndConsume(shared);
-            var stackValue = new StackValue(argArray.ToList());
-            ReturnValue = stackValue;
-        }
-    }
-
-    [Function("uniqueset")]
-    public class FunctionSet : SafeFunctionBase
-    {
-        public override void Execute(SafeSharedObjects shared)
-        {
-            Structure[] argArray = new Structure[CountRemainingArgs(shared)];
-            for (int i = argArray.Length - 1 ; i >= 0 ; --i)
-                argArray[i] = PopStructureAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
-            AssertArgBottomAndConsume(shared);
-            var setValue = new UniqueSetValue(argArray.ToList());
-            ReturnValue = setValue;
-        }
-    }
-
     [Function("range")]
     public class FunctionRange : SafeFunctionBase
     {
@@ -75,39 +17,24 @@ namespace kOS.Safe.Function
             // assign parameter values from the stack, pop them in reverse order
             switch (argCount)
             {
-            case 1:
-                to = GetInt(PopStructureAssertEncapsulated(shared));
-                break;
-            case 2:
-                to = GetInt(PopStructureAssertEncapsulated(shared));
-                from = GetInt(PopStructureAssertEncapsulated(shared));
-                break;
-            case 3:
-                step = GetInt(PopStructureAssertEncapsulated(shared));
-                to = GetInt(PopStructureAssertEncapsulated(shared));
-                from = GetInt(PopStructureAssertEncapsulated(shared));
-                break;
-            default:
-                throw new KOSArgumentMismatchException(new int[] { 1, 2, 3 }, argCount, "Thrown from function RANGE()");
+                case 1:
+                    to = GetInt(PopStructureAssertEncapsulated(shared));
+                    break;
+                case 2:
+                    to = GetInt(PopStructureAssertEncapsulated(shared));
+                    from = GetInt(PopStructureAssertEncapsulated(shared));
+                    break;
+                case 3:
+                    step = GetInt(PopStructureAssertEncapsulated(shared));
+                    to = GetInt(PopStructureAssertEncapsulated(shared));
+                    from = GetInt(PopStructureAssertEncapsulated(shared));
+                    break;
+                default:
+                    throw new KOSArgumentMismatchException(new int[] { 1, 2, 3 }, argCount, "Thrown from function RANGE()");
             }
             AssertArgBottomAndConsume(shared);
 
             ReturnValue = new RangeValue(from, to, step);
-        }
-    }
-
-    [Function("lex", "lexicon")]
-    public class FunctionLexicon : SafeFunctionBase
-    {
-        public override void Execute(SafeSharedObjects shared)
-        {
-
-            Structure[] argArray = new Structure[CountRemainingArgs(shared)];
-            for (int i = argArray.Length - 1 ; i >= 0 ; --i)
-                argArray[i] = PopStructureAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
-            AssertArgBottomAndConsume(shared);
-            var lexicon = new Lexicon(argArray.ToList());
-            ReturnValue = lexicon;
         }
     }
 

--- a/src/kOS.Safe/Persistence/PathValue.cs
+++ b/src/kOS.Safe/Persistence/PathValue.cs
@@ -4,6 +4,7 @@ using kOS.Safe.Persistence;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Encapsulation;
 using System.Linq;
+using kOS.Safe.Function;
 
 namespace kOS.Safe
 {
@@ -17,6 +18,32 @@ namespace kOS.Safe
     [kOS.Safe.Utilities.KOSNomenclature("Path")]
     public class PathValue : SerializableStructure, IHasSafeSharedObjects
     {
+        [Function("path")]
+        public class FunctionPath : SafeFunctionBase
+        {
+            public override void Execute(SafeSharedObjects shared)
+            {
+                int remaining = CountRemainingArgs(shared);
+
+                GlobalPath path;
+
+                if (remaining == 0)
+                {
+                    path = GlobalPath.FromVolumePath(shared.VolumeMgr.CurrentDirectory.Path,
+                                                     shared.VolumeMgr.GetVolumeRawIdentifier(shared.VolumeMgr.CurrentVolume));
+                }
+                else
+                {
+                    object pathObject = PopValueAssert(shared, true);
+                    path = shared.VolumeMgr.GlobalPathFromObject(pathObject);
+                }
+
+                AssertArgBottomAndConsume(shared);
+
+                ReturnValue = new PathValue(path, shared);
+            }
+        }
+
         private const string DumpPath = "path";
 
         public GlobalPath Path { get; private set; }

--- a/src/kOS.Safe/Persistence/Volume.cs
+++ b/src/kOS.Safe/Persistence/Volume.cs
@@ -3,12 +3,43 @@ using System.Linq;
 using kOS.Safe.Encapsulation;
 using kOS.Safe.Encapsulation.Suffixes;
 using kOS.Safe.Exceptions;
+using kOS.Safe.Function;
 
 namespace kOS.Safe.Persistence
 {
     [kOS.Safe.Utilities.KOSNomenclature("Volume")]
     public abstract class Volume : Structure
     {
+        [Function("volume")]
+        public class FunctionVolume : SafeFunctionBase
+        {
+            public override void Execute(SafeSharedObjects shared)
+            {
+                int remaining = CountRemainingArgs(shared);
+
+                Volume volume;
+
+                if (remaining == 0)
+                {
+                    volume = shared.VolumeMgr.CurrentVolume;
+                }
+                else
+                {
+                    object volumeId = PopValueAssert(shared, true);
+                    volume = shared.VolumeMgr.GetVolume(volumeId);
+
+                    if (volume == null)
+                    {
+                        throw new KOSPersistenceException("Could not find volume: " + volumeId);
+                    }
+                }
+
+                AssertArgBottomAndConsume(shared);
+
+                ReturnValue = volume;
+            }
+        }
+
         public const string TEXT_EXTENSION = "txt";
         public const string KERBOSCRIPT_EXTENSION = "ks";
         public const string KOS_MACHINELANGUAGE_EXTENSION = "ksm";


### PR DESCRIPTION
Lexicon.cs, ListValue.cs, PIDLoop.cs, QueueValue.cs
StackValue.cs, UniqueSetValue.cs, PathValue.cs, Volume.cs
* Added nested classes from Misc.cs, Persistence.cs, and Suffixed.cs to
  host kerboscript constructor functions within the associated structure

STYLEGUIDE.md
* Update style guide to specifically call out acceptability of nested
  classes and preference in the case of kerboscript constructor classes

Also some minor white space modifications and merging "develop"